### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@
 ```
 
 
-#English
+# English
 
 ## Abstract
 a material designed style dialog, can add operation of content view, set messages, respond to onclick of messages items and so on


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
